### PR TITLE
Fire and listen hook events at domRoot level

### DIFF
--- a/assets/phoenix_live_view/js/phoenix_live_view/live_socket.js
+++ b/assets/phoenix_live_view/js/phoenix_live_view/live_socket.js
@@ -839,7 +839,10 @@ export default class LiveSocket {
   }
 
   dispatchEvent(event, payload = {}){
-    DOM.dispatchEvent(window, `phx:${event}`, {detail: payload})
+    // lvp:comment-next-line
+    // DOM.dispatchEvent(window, `phx:${event}`, {detail: payload})
+    // lvp:add-next-line
+    DOM.dispatchEvent(this.domRoot, `phx:${event}`, {detail: payload})
   }
 
   dispatchEvents(events){

--- a/assets/phoenix_live_view/js/phoenix_live_view/view_hook.js
+++ b/assets/phoenix_live_view/js/phoenix_live_view/view_hook.js
@@ -296,14 +296,20 @@ export default class ViewHook {
 
   handleEvent(event, callback){
     let callbackRef = (customEvent, bypass) => bypass ? event : callback(customEvent.detail)
-    window.addEventListener(`phx:${event}`, callbackRef)
+    // lvp:comment-next-line
+    // window.addEventListener(`phx:${event}`, callbackRef)
+    // lvp:add-next-line
+    this.__view().domRoot.addEventListener(`phx:${event}`, callbackRef)
     this.__listeners.add(callbackRef)
     return callbackRef
   }
 
   removeHandleEvent(callbackRef){
     let event = callbackRef(null, true)
-    window.removeEventListener(`phx:${event}`, callbackRef)
+    // lvp:comment-next-line
+    // window.removeEventListener(`phx:${event}`, callbackRef)
+    // lvp:add-next-line
+    this.__view().domRoot.removeEventListener(`phx:${event}`, callbackRef)
     this.__listeners.delete(callbackRef)
   }
 


### PR DESCRIPTION
## Problem

Hook events were dispatched at `window` level, causing all embedded portal apps on the same page to receive events intended for a single portal instance. This led to cross-portal event leakage and unintended side effects when multiple portals were embedded.

## Solution

Hook events are now scoped to each portal app's `root` element instead of the global `window` object. This ensures proper event isolation between portal instances, preventing events from one portal being received by others.